### PR TITLE
Initial implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.12-alpine
+
+ENV LZ4_VERSION=1.9.1 \
+    LIBRDKAFKA_VERSION=1.1.0
+
+RUN apk update && apk upgrade && \
+    apk add curl bash build-base zlib-dev openssl-dev musl-dev make gcc g++ git && \
+    curl -Ls https://github.com/lz4/lz4/archive/v${LZ4_VERSION}.tar.gz | tar -xz -C /tmp && \
+    cd /tmp/lz4-${LZ4_VERSION} && make && make install && rm -fr /tmp/lz4-${LZ4_VERSION} && \
+    curl -Ls https://github.com/edenhill/librdkafka/archive/v${LIBRDKAFKA_VERSION}.tar.gz | tar -xz -C /tmp && \
+    cd /tmp/librdkafka-${LIBRDKAFKA_VERSION} && ./configure && make && make install && rm -fr /tmp/librdkafka-${LIBRDKAFKA_VERSION}
+
+WORKDIR /root
+
+CMD []

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Aerial Technologies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# docker-golang-kafka
+# Docker image with Go + librdkafka
+
+Build/tool image with Go 1.12, librkafaka and build tools (git, gcc, make...) installed and ready to run.
+
+Useful to run tests in CI and as base image for multi-stage builds.


### PR DESCRIPTION
The objective is to get a docker image with Go, the required libraries for Kafka (`librdkafka` and `LZ4`) and some build tools (`git`, `gcc`, `make`...).

This image can be used to run tests in CI and as a base image for multi-stage builds.