### PR TITLE
Debian stretch image

### DIFF
--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get dist-upgrade -y && \
     curl -Ls https://github.com/lz4/lz4/archive/v${LZ4_VERSION}.tar.gz | tar -xz -C /tmp && \
     cd /tmp/lz4-${LZ4_VERSION} && make && make install && rm -fr /tmp/lz4-${LZ4_VERSION} && \
     curl -Ls https://github.com/edenhill/librdkafka/archive/v${LIBRDKAFKA_VERSION}.tar.gz | tar -xz -C /tmp && \
-    cd /tmp/librdkafka-${LIBRDKAFKA_VERSION} && ./configure && make && make install && rm -fr /tmp/librdkafka-${LIBRDKAFKA_VERSION}
+    cd /tmp/librdkafka-${LIBRDKAFKA_VERSION} && ./configure && make && make install && rm -fr /tmp/librdkafka-${LIBRDKAFKA_VERSION} && \
+    ldconfig
 
 WORKDIR /root
 

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -1,0 +1,15 @@
+FROM golang:1.12-stretch
+
+ENV LZ4_VERSION=1.9.1 \
+    LIBRDKAFKA_VERSION=1.1.0
+
+RUN apt-get update && apt-get dist-upgrade -y && \
+    apt-get install -y bash zlib1g-dev libffi-dev build-essential make git && \
+    curl -Ls https://github.com/lz4/lz4/archive/v${LZ4_VERSION}.tar.gz | tar -xz -C /tmp && \
+    cd /tmp/lz4-${LZ4_VERSION} && make && make install && rm -fr /tmp/lz4-${LZ4_VERSION} && \
+    curl -Ls https://github.com/edenhill/librdkafka/archive/v${LIBRDKAFKA_VERSION}.tar.gz | tar -xz -C /tmp && \
+    cd /tmp/librdkafka-${LIBRDKAFKA_VERSION} && ./configure && make && make install && rm -fr /tmp/librdkafka-${LIBRDKAFKA_VERSION}
+
+WORKDIR /root
+
+CMD []

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 Build/tool image with Go 1.12, librkafaka and build tools (git, gcc, make...) installed and ready to run.
 
 Useful to run tests in CI and as base image for multi-stage builds.
+
+There are two images available, based on Alpine (default) and Debian stretch.
+
+If you plan to run tests with `ginkgo` and race detection enabled there's an issue with [Alpine](https://groups.google.com/forum/#!topic/golang-nuts/WnfKCoaRP_E).
+The Debian stretch must be used for this use case.


### PR DESCRIPTION
A new Dockerfile was added to build an image based on Debian stretch to fix an issue when running tests with `ginkgo` and race detection enabled.