### PR TITLE
Add ssh to stretch build

### DIFF
--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -4,7 +4,7 @@ ENV LZ4_VERSION=1.9.1 \
     LIBRDKAFKA_VERSION=1.1.0
 
 RUN apt-get update && apt-get dist-upgrade -y && \
-    apt-get install -y bash zlib1g-dev libffi-dev build-essential make git && \
+    apt-get install -y bash zlib1g-dev libffi-dev build-essential make git ssh && \
     curl -Ls https://github.com/lz4/lz4/archive/v${LZ4_VERSION}.tar.gz | tar -xz -C /tmp && \
     cd /tmp/lz4-${LZ4_VERSION} && make && make install && rm -fr /tmp/lz4-${LZ4_VERSION} && \
     curl -Ls https://github.com/edenhill/librdkafka/archive/v${LIBRDKAFKA_VERSION}.tar.gz | tar -xz -C /tmp && \


### PR DESCRIPTION
This PR adds SSH to the Stretch build. 

This is necessary in order to ensure SSH based git pulls can succeed without requiring to install SSH prior. 

The build as been tested locally.